### PR TITLE
Tweak map styles.

### DIFF
--- a/app/assets/stylesheets/styles.scss
+++ b/app/assets/stylesheets/styles.scss
@@ -103,8 +103,30 @@ h1 {
   }
 }
 
-.map img {
-  max-width: 100%;
+.map {
+  width: 560px;
+  height: 280px;
+  background-color: #eee;
+  border-radius: 5px;
+  position: relative;
+  overflow: hidden;
+
+  img {
+    width: 100%;
+    height: 100%;
+  }
+
+  &:after {
+    display: block;
+    content: "";
+    width: 100%;
+    height: 100%;
+    position: absolute;
+    box-shadow: inset 1px 1px 1px rgba(#000, 0.2);
+    top: 0;
+    border-radius: 5px;
+    pointer-events: none;
+  }
 }
 
 @keyframes status-graphic-bar-entrance {

--- a/app/views/serviceRequest.ejs
+++ b/app/views/serviceRequest.ejs
@@ -59,7 +59,7 @@
       <img src="https://maps.googleapis.com/maps/api/staticmap?<%= new URLSearchParams({
         center: request.coordinates,
         markers: request.coordinates,
-        size: "600x300",
+        size: "560x280",
         key: "AIzaSyBKs9MlfH-bo1lPMx5zS7u8gjDujY3vXO8",
         scale: 2,
         zoom: 15


### PR DESCRIPTION
This adds a box shadow and tweaks the sizing of the map to prevent resizing in the browser. It would be nice if we used responsive images here to adjust the size of the rendered map — I’ll create a follow-up issue!