### PR TITLE
Show warning when new service requests are stale.

### DIFF
--- a/app/api/dc311.mjs
+++ b/app/api/dc311.mjs
@@ -38,6 +38,41 @@ export default class DC311 {
       return new ServiceRequest(features[0].attributes)
     }
   }
+
+  static async getServiceRequests() {
+    const params = {
+      orderByFields: "ADDDATE desc",
+      f: "json"
+    }
+
+    const since = new Date()
+    since.setDate(since.getDate() - 7)
+
+    const ids = await this.getIds(Object.assign({
+      where: `ADDDATE > date '${since.toISOString().split("T")[0]}'`
+    }, params))
+
+    const qs = new URLSearchParams(Object.assign({
+      objectIds: ids.join(),
+      outFields: "*"
+    }, params))
+
+    const response = await fetch(`${endpoint}?${qs}`)
+    const { features } = await response.json()
+
+    return features.map((f) => new ServiceRequest(f.attributes))
+  }
+
+  static async getIds(options) {
+    const params = new URLSearchParams(Object.assign({
+      returnIdsOnly: true
+    }, options))
+
+    const response = await fetch(`${endpoint}?${params}`)
+    const { objectIds } = await response.json()
+
+    return objectIds.slice(0, 10)
+  }
 }
 
 Object.assign(DC311, { ServiceRequestNotFound })

--- a/app/assets/javascripts/client.mjs
+++ b/app/assets/javascripts/client.mjs
@@ -1,5 +1,9 @@
 import progressive from "./lib/progressive"
-import pages from "./pages/all"
+import LookupFeature from "./features/lookup"
+import OutdatedFeature from "./features/outdated"
 
-document.addEventListener("DOMContentLoaded", progressive.enhance)
-document.addEventListener("DOMContentLoaded", pages.initialize)
+document.addEventListener("DOMContentLoaded", () => {
+  progressive.enhance()
+  new LookupFeature()
+  new OutdatedFeature()
+})

--- a/app/assets/javascripts/features/lookup.mjs
+++ b/app/assets/javascripts/features/lookup.mjs
@@ -1,8 +1,8 @@
 import serviceRequestHelper from "../../../helpers/serviceRequest"
 
-export default class Index {
+export default class Lookup {
   constructor() {
-    if (!(this.form = document.querySelector(".service-request-lookup"))) {
+    if (!(this.form = document.querySelector(".lookup-feature"))) {
       return
     }
 

--- a/app/assets/javascripts/features/outdated.mjs
+++ b/app/assets/javascripts/features/outdated.mjs
@@ -1,0 +1,39 @@
+import humanizeDuration from "humanize-duration"
+import ServiceRequest from "../../../models/serviceRequest"
+
+const oneHourInMilliseconds = 3600000
+
+export default class Lookup {
+  constructor() {
+    if (!(this.container = document.querySelector(".outdated-feature"))) {
+      return
+    }
+
+    this.fetchAndRender()
+  }
+
+  async fetchAndRender() {
+    const response = await fetch("/requests/recent")
+    const body = await response.json()
+    this.render(new ServiceRequest(body[0]))
+  }
+
+  render(request) {
+    const timeSinceLastRequest = new Date() - request.requestedAt;
+
+    if (timeSinceLastRequest > oneHourInMilliseconds) {
+      this.container.hidden = false
+      this.container.innerHTML = `
+        <details>
+          <summary><strong>DC’s 311 OpenData database appears to be outdated.</strong></summary>
+
+          <p>It has been longer than usual since the last service request has been added — they are typically added every few minutes, but it has been <strong>${humanizeDuration(timeSinceLastRequest, { units: ["y", "mo", "d", "h", "m"], round: true })}</strong> since the last new service request.</p>
+
+          <p>This doesn’t mean there’s anything wrong with 311 — we as citizens have access to a different database than the one that is internally used by 311 in order to protect the privacy of those requesting city services. Sometimes it seems to lag behind — and it means that the data you see on this website is out of date.</p>
+
+          <p>If you know the email address associated with your service request, you can look it up directly in <a href="https://311.dc.gov" target="_blank" rel="noopener noreferrer">311’s database</a>.</p>
+        </details>
+      `
+    }
+  }
+}

--- a/app/assets/javascripts/pages/all.mjs
+++ b/app/assets/javascripts/pages/all.mjs
@@ -1,7 +1,0 @@
-import Index from "./index"
-
-export default {
-  initialize() {
-    new Index()
-  }
-}

--- a/app/assets/stylesheets/styles.scss
+++ b/app/assets/stylesheets/styles.scss
@@ -1,9 +1,14 @@
+html {
+  color: #000;
+  background-color: #fff;
+  font-family: sans-serif;
+  line-height: 1.5;
+}
+
 body {
   max-width: 600px;
   margin: 0 auto;
   padding: 20px;
-  font-family: sans-serif;
-  line-height: 1.5
 }
 
 * {
@@ -110,6 +115,7 @@ h1 {
   border-radius: 5px;
   position: relative;
   overflow: hidden;
+  flex-shrink: 0;
 
   img {
     width: 100%;
@@ -156,4 +162,15 @@ button {
   border: 1px #ccc solid;
   background: linear-gradient(#fff, #eee);
   cursor: pointer;
+}
+
+details {
+  summary {
+    display: inline-block;
+    cursor: pointer;
+  }
+
+  p:last-child {
+    margin-bottom: 0;
+  }
 }

--- a/app/routes.mjs
+++ b/app/routes.mjs
@@ -10,6 +10,12 @@ app.get("/", (req, res) => res.render("index", {
   requestNumberPattern: serviceRequestHelper.pattern
 }))
 
+app.get("/requests/recent", (req, res, next) => {
+  DC311.getServiceRequests()
+    .then((requests) => res.send(requests.map((r) => r.attributes)))
+    .catch(next)
+})
+
 app.get(serviceRequestHelper.pattern, (req, res, next) => {
   const requestNumber = `${req.params[0]}-${req.params[1]}`
 

--- a/app/views/index.ejs
+++ b/app/views/index.ejs
@@ -10,11 +10,13 @@
 
 <h1>DC 311 Service Request Lookup</h1>
 
+<div class="section with-background with-space error outdated-feature" hidden></div>
+
 <div class="section form with-space">
   <noscript>
     <p>To look up a service request, enable JavaScript in your browser or append a service request number to the URL: <code>https://www.dc311rn.com/18-00138559</code>.</p>
   </noscript>
-  <form class="yesscript service-request-lookup" hidden>
+  <form class="yesscript lookup-feature" hidden>
     <label for="serviceRequestNumber">Service Request Number</label>
     <input type="text" name="serviceRequestNumber" placeholder="18-00138559" id="serviceRequestNumber" required pattern="<%= requestNumberPattern.source %>" autofocus>
     <button>Search</button>

--- a/app/views/serviceRequest.ejs
+++ b/app/views/serviceRequest.ejs
@@ -20,6 +20,8 @@
 <div class="service-request">
   <h1><%= request.number %></h1>
 
+  <div class="section with-background with-space error outdated-feature" hidden></div>
+
   <div class="section status-graphic <%= request.isClosed ? "is-completed" : "" %>">
     <div class="status-graphic-section requested">Requested</div>
     <div class="status-graphic-section completed">Completed</div>

--- a/app/views/serviceRequestNotFound.ejs
+++ b/app/views/serviceRequestNotFound.ejs
@@ -10,13 +10,15 @@
 
 <h1>DC 311 Service Request Lookup</h1>
 
+<div class="section with-background with-space error outdated-feature" hidden></div>
+
 <div class="section with-background with-space error">
-  <p>We were unable to find <strong><%= requestNumber %></strong> in DC’s OpenData export of 311 service requests.</p>
+  <p>We were unable to find <strong><%= requestNumber %></strong> in DC’s OpenData database of 311 service requests.</p>
 </div>
 
 <div class="section explanation">
   <h2>Why?</h2>
-  <p>This doesn’t mean that your service request is lost — sometimes the export of service requests lags behind 311’s internal database, which we don’t have access to.</p>
+  <p>This doesn’t mean that your service request is lost — sometimes the database of service requests lags behind 311’s internal database, which we don’t have access to.</p>
 
   <p>If you know the email address associated with this service request, you can look it up directly in 311’s database.</p>
 
@@ -28,7 +30,7 @@
     <button>Go to 311.dc.gov</button>
   </form>
 
-  <h2>What’s DC 311’s OpenData export?</h2>
+  <h2>What’s DC 311’s OpenData database?</h2>
 
   <p>The citizens of DC pay for our 311 service, and we pay for service requests to be stored electronically in a searchable format in order for 311 to be effective. DC realizes that data’s greatest value comes from having it freely shared among agencies, federal and regional governments and with the public to the extent possible when considering safety, privacy and security.</p>
 

--- a/server.mjs
+++ b/server.mjs
@@ -23,6 +23,7 @@ app.use(helmet.contentSecurityPolicy({
     defaultSrc: ["'none'"],
     styleSrc: isProduction ? ["https://assets.dc311rn.com"] : ["'self'"],
     scriptSrc: isProduction ? ["https://assets.dc311rn.com"] : ["'self'", "'unsafe-eval'"],
+    connectSrc: ["'self'"],
     imgSrc: ["https://maps.googleapis.com"],
     upgradeInsecureRequests: isProduction
   },


### PR DESCRIPTION
DC’s 311 OpenData database is currently out of date — requests are usually added every few minutes, but it’s been more than 4 days since the database has been updated. Since we can detect this, let’s show a warning when we notice the database is out of date.

| As shown initially | When expanded |
|-------------|----------------|
| ![Screenshot of collapsed warning](https://user-images.githubusercontent.com/14930/39154502-51bc0608-471c-11e8-8e75-532b5ea36992.png) | ![Screenshot of expanded warning](https://user-images.githubusercontent.com/14930/39154513-5906aaa8-471c-11e8-821a-5afabdf49d4f.png) |

Another spin-off of #5.