### PR TITLE
Add details section.

### DIFF
--- a/app/models/serviceRequest.mjs
+++ b/app/models/serviceRequest.mjs
@@ -24,6 +24,8 @@ export default class ServiceRequest {
   get type() { return this.attributes.SERVICECODEDESCRIPTION }
   get department() { return this.attributes.SERVICETYPECODEDESCRIPTION }
   get organization() { return this.attributes.ORGANIZATIONACRONYM }
+  get hasDetails() { return !!this.details }
+  get details() { return this.attributes.DETAILS }
 
   get requestedAt() { return toDate(this.attributes.SERVICEORDERDATE) }
   get dueAt() { return toDate(this.attributes.SERVICEDUEDATE) }

--- a/app/views/serviceRequest.ejs
+++ b/app/views/serviceRequest.ejs
@@ -46,6 +46,13 @@
     </div>
   </div>
 
+  <% if (request.hasDetails) { %>
+    <div class="section details with-icon">
+      <div class="icon">📝</div>
+      <div><%= request.details %></div>
+    </div>
+  <% } %>
+
   <% if (request.hasAddress) { %>
     <div class="section address with-icon">
       <div class="icon">📍</div>
@@ -53,7 +60,7 @@
     </div>
   <% } %>
 
-  <div class="section map">
+  <div class="section with-space map">
     <a href="https://www.google.com/maps/search/?<%= new URLSearchParams({
       api: 1,
       query: request.coordinates
@@ -65,7 +72,7 @@
         key: "AIzaSyBKs9MlfH-bo1lPMx5zS7u8gjDujY3vXO8",
         scale: 2,
         zoom: 15
-      }) %>">
+      }) %>" alt="Map of service request coordinates <%= request.coordinates %>">
     </a>
   </div>
 
@@ -75,7 +82,7 @@
     <form action="https://311.dc.gov/" method="GET">
       <input type="hidden" name="serviceRequestId" value="<%= request.id %>">
       <label for="email">Email Address</label>
-      <input type="email" name="email" id="email" required autofocus>
+      <input type="email" name="email" id="email" required>
 
       <button>Go to 311.dc.gov</button>
     </form>


### PR DESCRIPTION
When browsing service requests, I noticed that some have interesting information in the DETAILS field. This PR:

1. Adds that field to the UI.
2. Makes a few tweaks to the map spacing.
3. Adds an ALT tag to the map image that should have been there before.

![image](https://user-images.githubusercontent.com/14930/39154819-a3480f34-471d-11e8-877e-4cda37a1ef82.png)
