### PR TITLE
Fix routing by removing `g` regexp flag.

### DIFF
--- a/app/helpers/serviceRequest.mjs
+++ b/app/helpers/serviceRequest.mjs
@@ -1,5 +1,3 @@
 export default {
-  get pattern() {
-    return /(\d{2})-?(\d{8})/g
-  }
+  pattern: /(\d{2})-?(\d{8})/
 }

--- a/app/models/tweet.mjs
+++ b/app/models/tweet.mjs
@@ -12,7 +12,7 @@ export default class Tweet {
   get createdAt() { return new Date(Date.parse(this.attributes.created_at)) }
   get serviceRequestNumbers() {
     const numbers = []
-    const pattern = serviceRequestHelper.pattern
+    const pattern = new RegExp(serviceRequestHelper.pattern, "g")
     let matches
 
     while (matches = pattern.exec(this.text)) {


### PR DESCRIPTION
Introduced in #5.

Adding `g` to the general purpose RegExp for service requests causes the route handler to have state — so every other route doesn’t match the regular expression anymore.

This isn’t ideal — instead, let’s add the `g` flag only in the tweet object where it’s required.