### PR TITLE
Allow asset responses to be cached for 1 year.

### DIFF
--- a/app/assets.js
+++ b/app/assets.js
@@ -26,7 +26,10 @@ else {
     css: `${config.output.publicPath}${manifest["styles.css"]}`
   }
 
-  app.use("/cloudfront-asset-requests", express.static("dist/"))
+  app.use("/cloudfront-asset-requests", express.static("dist/", {
+    maxAge: 31536000000,
+    immutable: true
+  }))
 }
 
 module.exports = app


### PR DESCRIPTION
A follow-up to 53e18fd82a1530d601b240aab2048a1f6a4ab475, this PR attempts to further enable caching by Cloudfront, since requests for assets are still hitting our node server. Hopefully after this PR, only the first requests to these will hit node, and the rest will be served by Cloudfront directly.