### PR TITLE
Remove Cloudfront URL.

### DIFF
--- a/app/assets.js
+++ b/app/assets.js
@@ -33,16 +33,10 @@ else {
     css: `${path}/${manifest["styles.css"]}`
   }
 
-  const middleware = express.static("dist/", {
+  app.use("/assets", express.static("dist/", {
     maxAge: 31536000000,
     immutable: true
-  })
-
-  app.use("/assets", middleware)
-
-  // Transition from cloudfront-* path to assets to simplify staging setup.
-  // Once cloudfront configuration has fully propogated, this path can be removed.
-  app.use("/cloudfront-asset-requests", middleware)
+  }))
 }
 
 module.exports = app


### PR DESCRIPTION
Cloudfront is now configured to hit /assets instead, which simplifies the configuration between staging and production.

This PR needs to wait for Cloudfront’s configuration change to propagate, probably a few hours or so should be plenty of time. We can verify that no requests are coming to `cloudfront-*` URLs to ensure the configuration has been deployed.

This change was initiated in #31, which introduced the support for both URLs so Cloudfront’s configuration could be updated. 