### PR TITLE
Change servers depending on the service request.

### DIFF
--- a/app/api/dc311.test.js
+++ b/app/api/dc311.test.js
@@ -53,3 +53,13 @@ describe("getServiceRequests", () => {
     })
   })
 })
+
+describe("getEndpoint", () => {
+  test("it contacts map server 9 for service requests in 2018", () => {
+    expect(DC311.getEndpoint("18")).toMatch(/.*9$/)
+  })
+
+  test("it contacts map server 10 for service requests in 2019", () => {
+    expect(DC311.getEndpoint("19")).toMatch(/.*10$/)
+  })
+})


### PR DESCRIPTION
Fixes #45. /cc @dschep (thanks for the nudge!)

Unfortunately the endpoint for service requests changes depending on the year. This PR switches endpoints depending on the service request number requested to the appropriate one.